### PR TITLE
Security Fix for Prototype Pollution in cytoscape.js

### DIFF
--- a/src/util/maps.js
+++ b/src/util/maps.js
@@ -44,8 +44,9 @@ export const setMap = options => {
       if( obj[ key ] == null ){
         obj[ key ] = {};
       }
-
-      obj = obj[ key ];
+      if (key !== '__proto__' && key !== 'constructor' && key !== 'prototype') {
+        obj = obj[ key ];
+      }
     } else {
       // set the value
       obj[ key ] = options.value;

--- a/src/util/maps.js
+++ b/src/util/maps.js
@@ -44,6 +44,7 @@ export const setMap = options => {
       if( obj[ key ] == null ){
         obj[ key ] = {};
       }
+      
       if (key !== '__proto__' && key !== 'constructor' && key !== 'prototype') {
         obj = obj[ key ];
       }


### PR DESCRIPTION
### 📊 Metadata *
The ``setMap`` in ``cytoscape`` is subject to prototype pollution due to the recursely copy ``obj[key]`` to ``obj`` in the code. This vulnerble API is exported to be called by the end users throgh cytoscape constructor. This vulnerability allows modification of the Object prototype. If an attacker can control part of the structure passed to this function, they could add or modify an existing property. Possibly leading to many kinds of attacks such as the denial-of-service, checking bypass, or potentially code execution.

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-cytoscape/

### ⚙️ Description *
Sanitize the ``key`` before the code ``obj = obj[ key ];``.

### 💻 Technical Description *
```
if (key !== '__proto__' && key !== 'constructor' && key !== 'prototype') {
        obj = obj[ key ];
      }
```

### 🐛 Proof of Concept (PoC) *
```
// PoC.js
var cytoscape=require('cytoscape');
console.log('Before: ' + {}.polluted);//Before: undefined
cytoscape('__proto__','polluted','HACKED');
console.log('After: ' + {}.polluted); //After: HACKED
```

### 🔥 Proof of Fix (PoF) *
```
// PoF.js
var cytoscape=require('cytoscape');
console.log('Before: ' + {}.polluted);//Before: undefined
cytoscape('__proto__','polluted','HACKED');
console.log('After: ' + {}.polluted); //After: undefined
```

### 👍 User Acceptance Testing (UAT)
![image](https://user-images.githubusercontent.com/834641/112825965-f4317500-90be-11eb-9014-af6c91b332d5.png)

