### PR TITLE
Security Fix for Prototype Pollution in cytoscape.js (version 2)

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -172,6 +172,9 @@ function setExtension( type, name, registrant ){
 
     ext = Renderer;
 
+  } else if (type === '__proto__' || type === 'constructor' || type === 'prototype'){
+    // to avoid potential prototype pollution
+    return util.error( type + ' is an illegal type to be registered, possibly lead to prototype pollutions' );
   }
 
   return util.setMap( {


### PR DESCRIPTION
### 📊 Metadata *
The ``setMap`` in ``cytoscape`` is subject to prototype pollution due to the recursely copy ``obj[key]`` to ``obj`` in the code. This vulnerble API is exported to be called by the end users throgh cytoscape constructor. This vulnerability allows modification of the Object prototype. If an attacker can control part of the structure passed to this function, they could add or modify an existing property. Possibly leading to many kinds of attacks such as the denial-of-service, checking bypass, or potentially code execution.

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-cytoscape/

### ⚙️ Description *
Sanitize the ``type`` before calling  ``setMap``.

### 💻 Technical Description *
```
  } else if (type === '__proto__' || type === 'constructor' || type === 'prototype'){
    // to avoid potential prototype pollution
    return util.error( type + ' is an illegal type to be registered, possibly lead to prototype pollutions' );
  }
```

### 🐛 Proof of Concept (PoC) *
```
// PoC.js
var cytoscape=require('cytoscape');
console.log('Before: ' + {}.polluted);//Before: undefined
cytoscape('__proto__','polluted','HACKED');
console.log('After: ' + {}.polluted); //After: HACKED
```

### 🔥 Proof of Fix (PoF) *
```
// PoF.js
var cytoscape=require('cytoscape');
console.log('Before: ' + {}.polluted);//Before: undefined
cytoscape('__proto__','polluted','HACKED');
//Error: __proto__ is an illegal type to be registered, possibly lead to prototype pollutions
```

### 👍 User Acceptance Testing (UAT)
